### PR TITLE
Implement visual panel for conversation history

### DIFF
--- a/components/conversation_card.py
+++ b/components/conversation_card.py
@@ -203,7 +203,7 @@ class ConversationCard:
                         type="button",
                         **{"aria-label": "Nueva conversación"}
                     ),
-                    class_="flex justify-center px-2 py-3 shrink-0"
+                    class_="flex justify-center px-4 py-3 shrink-0"
                 ),
                 
                 # Main content area (only visible when expanded)
@@ -258,7 +258,7 @@ class ConversationCard:
                         type="button",
                         **{"aria-label": "Configuración"}
                     ),
-                    class_="flex justify-center px-2 py-3 border-t border-gray-200 mt-auto shrink-0"
+                    class_="flex justify-center px-2 py-3 group-data-[state=collapsed]/sidebar:pt-[0.1rem] group-data-[state=collapsed]/sidebar:pb-1.5 border-t border-gray-200 mt-auto shrink-0"
                 ),
                 
                 class_="flex flex-col h-full w-full"

--- a/components/conversation_card.py
+++ b/components/conversation_card.py
@@ -1,32 +1,250 @@
-"""Conversation card component for DOF Chat."""
+"""Conversation card and History Panel components for DOF Chat - ChatGPT Style."""
 
 import air
+from typing import Optional
+from utils.mock_data import MOCK_CONVERSATIONS
+
+
+# SVG Icons as constants (only for UI controls, NOT for conversation items)
+ICON_MORE = """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>"""
+
+ICON_EDIT = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>"""
+
+ICON_TRASH = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>"""
+
+ICON_SHARE = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>"""
+
+ICON_MENU = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>"""
+
+ICON_PLUS = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>"""
+
+ICON_SETTINGS = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/></svg>"""
 
 
 class ConversationCard:
-    """Component for rendering conversation cards and summaries.
+    """Component for rendering conversation cards in ChatGPT style.
     
-    TODO: Future implementation for conversation history/list feature.
-    Currently not needed as the app focuses on single demo conversations.
-    The context_renderer.py already handles accordion-based context display.
+    Renders individual conversation items for the history sidebar panel
+    with title, preview text, icons, and hover actions.
     """
     
     @staticmethod
-    def create(title: str, preview: str, **kwargs) -> air.Div:
-        """TODO: Create a conversation card component.
-        
-        This is a placeholder for future conversation history functionality.
-        Currently the app only supports single demo conversations.
+    def create(
+        title: str, 
+        conversation_id: str = "",
+        is_active: bool = False,
+        **kwargs
+    ) -> air.Div:
+        """Create a conversation card component in ChatGPT style.
         
         Args:
-            title: Conversation title
-            preview: Preview text
+            title: Conversation title (truncated if too long)
+            conversation_id: Unique identifier for the conversation
+            is_active: Whether this card is currently selected
             **kwargs: Additional attributes
             
         Returns:
-            Air Div placeholder component
+            Air Div component representing a conversation card
+        """
+        active_class = " active" if is_active else ""
+        
+        return air.Div(
+            # Content area (solo título) - como en la imagen de referencia
+            air.Div(
+                air.Span(title, class_="history-item-title"),
+                class_="history-item-content"
+            ),
+            
+            # Actions container (visible on hover)
+            air.Div(
+                # Menu trigger button (3 dots)
+                air.Button(
+                    air.Raw(ICON_MORE),
+                    class_="history-menu-trigger",
+                    type="button",
+                    **{"aria-label": "Opciones de conversación", "data-conversation-id": conversation_id}
+                ),
+                # Dropdown menu (hidden by default)
+                air.Div(
+                    air.Button(
+                        air.Span(air.Raw(ICON_SHARE), class_="menu-item-icon"),
+                        air.Span("Compartir"),
+                        class_="history-menu-item"
+                    ),
+                    air.Button(
+                        air.Span(air.Raw(ICON_EDIT), class_="menu-item-icon"),
+                        air.Span("Renombrar"),
+                        class_="history-menu-item"
+                    ),
+                    air.Button(
+                        air.Span(air.Raw(ICON_TRASH), class_="menu-item-icon"),
+                        air.Span("Eliminar"),
+                        class_="history-menu-item delete"
+                    ),
+                    class_="history-dropdown-menu hidden"
+                ),
+                class_="history-item-actions-container"
+            ),
+            
+            class_=f"history-item{active_class}",
+            **{"data-conversation-id": conversation_id},
+            **kwargs
+        )
+    
+    @staticmethod
+    def create_group(group_title: str, cards: list) -> air.Div:
+        """Create a group of conversation cards with a date header.
+        
+        Args:
+            group_title: Title for the group (e.g., "HOY", "AYER")
+            cards: List of ConversationCard components
+            
+        Returns:
+            Air Div component containing the grouped cards
         """
         return air.Div(
-            f"TODO: ConversationCard - {title}: {preview}",
-            class_="conversation-card-placeholder"
+            air.Div(group_title, class_="history-group-title"),
+            *cards,
+            class_="history-group"
+        )
+    
+    @staticmethod
+    def create_panel(
+        conversations: Optional[dict] = None,
+        active_id: Optional[str] = "conv-003",
+        expanded: bool = True
+    ) -> air.Aside:
+        """Create the complete history sidebar panel.
+        
+        Args:
+            conversations: Dict of date groups with conversation lists
+            active_id: ID of the currently active conversation
+            expanded: Whether the sidebar starts expanded
+            
+        Returns:
+            Air Aside component for the sidebar
+        """
+        if conversations is None:
+            conversations = MOCK_CONVERSATIONS
+            
+        expanded_class = " expanded" if expanded else ""
+        
+        # Build conversation groups
+        conversation_groups = []
+        for group_title, convs in conversations.items():
+            cards = []
+            for conv in convs:
+                is_active = conv.get("id") == active_id
+                cards.append(
+                    ConversationCard.create(
+                        title=conv["title"],
+                        conversation_id=conv["id"],
+                        is_active=is_active
+                    )
+                )
+            if cards:
+                conversation_groups.append(
+                    ConversationCard.create_group(group_title, cards)
+                )
+        
+        return air.Aside(
+            # Inner column container
+            air.Div(
+                # Header with toggle button
+                air.Div(
+                    air.Button(
+                        air.Raw(ICON_MENU),
+                        class_="sidebar-icon-btn",
+                        id="sidebar-toggle",
+                        type="button",
+                        **{"aria-label": "Alternar barra lateral"}
+                    ),
+                    class_="sidebar-header"
+                ),
+                
+                # Actions section (New conversation button)
+                air.Div(
+                    air.Button(
+                        air.Raw(ICON_PLUS),
+                        air.Span("Nueva conversación", class_="sidebar-label"),
+                        class_="new-chat-btn",
+                        id="new-chat-btn",
+                        type="button",
+                        **{"aria-label": "Nueva conversación"}
+                    ),
+                    class_="sidebar-actions"
+                ),
+                
+                # Main content area (only visible when expanded)
+                air.Div(
+                    # Search input
+                    air.Div(
+                        air.Input(
+                            type="search",
+                            placeholder="Buscar...",
+                            class_="history-search-input",
+                            id="history-search",
+                            **{"aria-label": "Buscar conversaciones"}
+                        ),
+                        class_="history-search-container"
+                    ),
+                    
+                    # Section title
+                    air.Div("Recientes", class_="history-section-title"),
+                    
+                    # Scrollable history list
+                    air.Div(
+                        *conversation_groups,
+                        class_="history-scroll-area",
+                        id="history-list"
+                    ),
+                    
+                    class_="sidebar-main-content"
+                ),
+                
+                # Footer with settings
+                air.Div(
+                    air.Button(
+                        air.Raw(ICON_SETTINGS),
+                        air.Span("Configuración", class_="sidebar-label"),
+                        class_="sidebar-footer-btn",
+                        id="settings-btn",
+                        type="button",
+                        **{"aria-label": "Configuración"}
+                    ),
+                    class_="sidebar-footer"
+                ),
+                
+                class_="sidebar-inner-col"
+            ),
+            
+            class_=f"sidebar{expanded_class}",
+            id="history-sidebar"
+        )
+    
+    @staticmethod
+    def create_mobile_toggle() -> air.Button:
+        """Create the mobile toggle button (visible only on small screens).
+        
+        Returns:
+            Air Button component for mobile sidebar toggle
+        """
+        return air.Button(
+            air.Raw(ICON_MENU),
+            class_="mobile-toggle",
+            id="mobile-sidebar-toggle",
+            type="button",
+            **{"aria-label": "Abrir menú lateral"}
+        )
+    
+    @staticmethod
+    def create_overlay() -> air.Div:
+        """Create the mobile overlay for sidebar.
+        
+        Returns:
+            Air Div component for the overlay
+        """
+        return air.Div(
+            class_="sidebar-overlay",
+            id="sidebar-overlay"
         )

--- a/components/conversation_card.py
+++ b/components/conversation_card.py
@@ -169,7 +169,7 @@ class ConversationCard:
         return air.Aside(
             # Inner column container
             air.Div(
-                # Header with toggle button
+                # Header with toggle and search buttons
                 air.Div(
                     ad.Button(
                         air.Raw(_icon("menu", 20)),
@@ -179,7 +179,15 @@ class ConversationCard:
                         type="button",
                         **{"aria-label": "Alternar barra lateral"}
                     ),
-                    class_="flex items-center justify-center w-[52px] py-3 h-12 shrink-0"
+                    ad.Button(
+                        air.Raw(_icon("search", 20)),
+                        modifier=ad.ButtonMods.ghost,
+                        class_="w-8 h-8 rounded-full flex items-center justify-center hover:bg-gray-200 transition-colors group-data-[state=collapsed]/sidebar:hidden",
+                        id="search-trigger",
+                        type="button",
+                        **{"aria-label": "Buscar conversaciones"}
+                    ),
+                    class_="flex items-center justify-between px-2 py-3 h-12 shrink-0 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:w-[52px]"
                 ),
                 
                 # Actions section (New conversation button)
@@ -208,18 +216,6 @@ class ConversationCard:
                 
                 # Main content area (only visible when expanded)
                 air.Div(
-                    # Search input
-                    air.Div(
-                        air.Input(
-                            type="search",
-                            placeholder="Buscar...",
-                            class_="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg bg-white focus:outline-none focus:border-indigo-500",
-                            id="history-search",
-                            **{"aria-label": "Buscar conversaciones"}
-                        ),
-                        class_="px-4 mb-2"
-                    ),
-                    
                     # Section title
                     air.Div(
                         "Recientes",
@@ -295,4 +291,92 @@ class ConversationCard:
         return air.Div(
             class_="fixed inset-0 bg-black bg-opacity-30 z-40 hidden",
             id="sidebar-overlay"
+        )
+    @staticmethod
+    def create_search_view(conversations: Optional[dict] = None) -> air.Div:
+        """Create the inline search view that replaces chat area (Gemini-style).
+        
+        Args:
+            conversations: Dict of date groups with conversation lists
+            
+        Returns:
+            Air Div component for the search view
+        """
+        if conversations is None:
+            conversations = MOCK_CONVERSATIONS
+        
+        # Build flat list of all conversations
+        all_conversations = []
+        for group_title, convs in conversations.items():
+            for conv in convs:
+                all_conversations.append({
+                    **conv,
+                    "group": group_title
+                })
+        
+        # Create result items with improved styling
+        result_items = []
+        for conv in all_conversations:
+            result_items.append(
+                air.Div(
+                    air.Div(
+                        air.Span(
+                            conv["title"],
+                            class_="text-base text-gray-800 font-medium truncate",
+                            **{"data-search-title": "true"}
+                        ),
+                        class_="flex-1 min-w-0"
+                    ),
+                    air.Span(
+                        conv["group"],
+                        class_="text-xs text-gray-400 ml-6 whitespace-nowrap uppercase tracking-wide"
+                    ),
+                    class_="flex items-center justify-between px-5 py-4 hover:bg-indigo-50 cursor-pointer rounded-xl transition-all duration-200 border border-transparent hover:border-indigo-100",
+                    **{"data-conversation-id": conv["id"], "data-search-result": "true"}
+                )
+            )
+        
+        return air.Div(
+            # Centered content wrapper
+            air.Div(
+                # Header with nice spacing
+                air.H1(
+                    "Buscar",
+                    class_="text-3xl font-bold text-gray-900 mb-8"
+                ),
+                
+                # Search input (pill style, compact)
+                air.Div(
+                    air.Div(
+                        air.Raw(_icon("search", 18)),
+                        class_="text-gray-400"
+                    ),
+                    air.Input(
+                        type="search",
+                        placeholder="Buscar chats...",
+                        class_="flex-1 ml-3 text-base bg-transparent border-none outline-none placeholder-gray-400 text-gray-700",
+                        id="search-input",
+                        **{"aria-label": "Buscar conversaciones", "autocomplete": "off"}
+                    ),
+                    class_="flex items-center px-4 py-2.5 bg-gray-50 rounded-full border border-gray-200 focus-within:border-indigo-300 focus-within:ring-2 focus-within:ring-indigo-100 transition-all duration-200"
+                ),
+                
+                # Section title with spacing
+                air.Div(
+                    "Recientes",
+                    class_="text-sm font-semibold text-gray-500 uppercase tracking-wider mt-10 mb-4 px-2"
+                ),
+                
+                # Results list with gap
+                air.Div(
+                    *result_items,
+                    class_="flex flex-col gap-1",
+                    id="search-results"
+                ),
+                
+                class_="w-full max-w-2xl mx-auto"
+            ),
+            
+            class_="flex-1 flex flex-col items-center pt-16 px-8 pb-8 bg-white overflow-auto hidden",
+            id="search-view"
         )

--- a/components/conversation_card.py
+++ b/components/conversation_card.py
@@ -1,24 +1,15 @@
 """Conversation card and History Panel components for DOF Chat - ChatGPT Style."""
 
 import air
+import airdragon as ad
 from typing import Optional
-from utils.mock_data import MOCK_CONVERSATIONS
+from utils.mock_history_data import MOCK_CONVERSATIONS
 
 
-# SVG Icons as constants (only for UI controls, NOT for conversation items)
-ICON_MORE = """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>"""
-
-ICON_EDIT = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>"""
-
-ICON_TRASH = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>"""
-
-ICON_SHARE = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>"""
-
-ICON_MENU = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>"""
-
-ICON_PLUS = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>"""
-
-ICON_SETTINGS = """<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/></svg>"""
+# Helper to reference SVG sprite icons
+def _icon(name: str, size: int = 20) -> str:
+    """Generate SVG element referencing the sprite."""
+    return f'<svg width="{size}" height="{size}" class="shrink-0"><use href="/static/svg/icons.svg#icon-{name}"></use></svg>'
 
 
 class ConversationCard:
@@ -35,7 +26,7 @@ class ConversationCard:
         is_active: bool = False,
         **kwargs
     ) -> air.Div:
-        """Create a conversation card component in ChatGPT style.
+        """Create a conversation card component using AirDragon utilities.
         
         Args:
             title: Conversation title (truncated if too long)
@@ -46,48 +37,67 @@ class ConversationCard:
         Returns:
             Air Div component representing a conversation card
         """
-        active_class = " active" if is_active else ""
+        # Base classes
+        base_classes = (
+            "group flex items-center gap-2 px-4 py-2.5 rounded-lg cursor-pointer "
+            "transition-colors hover:bg-gray-100 mb-0.5 "
+            "data-[active=true]:bg-gray-100 data-[active=true]:border-l-4 "
+            "data-[active=true]:border-purple-500"
+        )
         
         return air.Div(
-            # Content area (solo título) - como en la imagen de referencia
+            # Content area
             air.Div(
-                air.Span(title, class_="history-item-title"),
-                class_="history-item-content"
+                air.Span(
+                    title,
+                    class_="text-sm font-medium text-gray-800 truncate block",
+                    **{"data-conversation-title": "true"}
+                ),
+                class_="flex-1 min-w-0"
             ),
             
             # Actions container (visible on hover)
             air.Div(
                 # Menu trigger button (3 dots)
-                air.Button(
-                    air.Raw(ICON_MORE),
-                    class_="history-menu-trigger",
+                ad.Button(
+                    air.Raw(_icon("more", 18)),
+                    modifier=ad.ButtonMods.ghost,
+                    class_="w-7 h-7 rounded-full opacity-0 group-hover:opacity-100 transition-opacity",
                     type="button",
-                    **{"aria-label": "Opciones de conversación", "data-conversation-id": conversation_id}
+                    **{"aria-label": "Opciones de conversación", "data-menu-trigger": "true"}
                 ),
                 # Dropdown menu (hidden by default)
                 air.Div(
-                    air.Button(
-                        air.Span(air.Raw(ICON_SHARE), class_="menu-item-icon"),
+                    ad.Button(
+                        air.Span(air.Raw(_icon("share", 16)), class_="w-4 h-4 opacity-70"),
                         air.Span("Compartir"),
-                        class_="history-menu-item"
+                        modifier=ad.ButtonMods.ghost,
+                        class_="flex items-center gap-2 w-full justify-start px-3 py-2 text-sm hover:bg-gray-100",
+                        **{"data-action": "share"}
                     ),
-                    air.Button(
-                        air.Span(air.Raw(ICON_EDIT), class_="menu-item-icon"),
+                    ad.Button(
+                        air.Span(air.Raw(_icon("edit", 16)), class_="w-4 h-4 opacity-70"),
                         air.Span("Renombrar"),
-                        class_="history-menu-item"
+                        modifier=ad.ButtonMods.ghost,
+                        class_="flex items-center gap-2 w-full justify-start px-3 py-2 text-sm hover:bg-gray-100",
+                        **{"data-action": "rename"}
                     ),
-                    air.Button(
-                        air.Span(air.Raw(ICON_TRASH), class_="menu-item-icon"),
+                    ad.Button(
+                        air.Span(air.Raw(_icon("trash", 16)), class_="w-4 h-4 opacity-70"),
                         air.Span("Eliminar"),
-                        class_="history-menu-item delete"
+                        modifier=ad.ButtonMods.ghost,
+                        class_="flex items-center gap-2 w-full justify-start px-3 py-2 text-sm text-red-600 hover:bg-red-50",
+                        **{"data-action": "delete"}
                     ),
-                    class_="history-dropdown-menu hidden"
+                    class_="hidden absolute right-0 top-8 bg-white border border-gray-200 rounded-lg shadow-lg p-1 z-50 min-w-[140px] flex-col gap-0.5",
+                    **{"data-dropdown": "true"}
                 ),
-                class_="history-item-actions-container"
+                class_="relative",
+                **{"data-dropdown-container": "true"}
             ),
             
-            class_=f"history-item{active_class}",
-            **{"data-conversation-id": conversation_id},
+            class_=base_classes,
+            **{"data-conversation-id": conversation_id, "data-active": "true" if is_active else "false"},
             **kwargs
         )
     
@@ -103,9 +113,16 @@ class ConversationCard:
             Air Div component containing the grouped cards
         """
         return air.Div(
-            air.Div(group_title, class_="history-group-title"),
-            *cards,
-            class_="history-group"
+            air.Div(
+                group_title,
+                class_="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide"
+            ),
+            air.Div(
+                *cards,
+                class_="flex flex-col ml-2"
+            ),
+            class_="mb-2",
+            **{"data-conversation-group": "true"}
         )
     
     @staticmethod
@@ -114,7 +131,7 @@ class ConversationCard:
         active_id: Optional[str] = "conv-003",
         expanded: bool = True
     ) -> air.Aside:
-        """Create the complete history sidebar panel.
+        """Create the complete history sidebar panel using AirDragon utilities.
         
         Args:
             conversations: Dict of date groups with conversation lists
@@ -126,8 +143,6 @@ class ConversationCard:
         """
         if conversations is None:
             conversations = MOCK_CONVERSATIONS
-            
-        expanded_class = " expanded" if expanded else ""
         
         # Build conversation groups
         conversation_groups = []
@@ -147,32 +162,48 @@ class ConversationCard:
                     ConversationCard.create_group(group_title, cards)
                 )
         
+        # Sidebar classes with Tailwind - maintaining current design
+        sidebar_base = "flex flex-col h-full bg-gray-50 border-r border-gray-200 transition-all duration-300 ease-in-out overflow-hidden z-50"
+
+        
         return air.Aside(
             # Inner column container
             air.Div(
                 # Header with toggle button
                 air.Div(
-                    air.Button(
-                        air.Raw(ICON_MENU),
-                        class_="sidebar-icon-btn",
+                    ad.Button(
+                        air.Raw(_icon("menu", 20)),
+                        modifier=ad.ButtonMods.ghost,
+                        class_="w-8 h-8 rounded-full flex items-center justify-center",
                         id="sidebar-toggle",
                         type="button",
                         **{"aria-label": "Alternar barra lateral"}
                     ),
-                    class_="sidebar-header"
+                    class_="flex items-center justify-center w-[52px] py-3 h-12 shrink-0"
                 ),
                 
                 # Actions section (New conversation button)
                 air.Div(
-                    air.Button(
-                        air.Raw(ICON_PLUS),
-                        air.Span("Nueva conversación", class_="sidebar-label"),
-                        class_="new-chat-btn",
+                    ad.Button(
+                        air.Raw(_icon("plus", 20)),
+                        air.Span(
+                            "Nueva conversación",
+                            class_="ml-3 text-sm font-medium whitespace-nowrap opacity-100 group-data-[state=collapsed]/sidebar:opacity-0 group-data-[state=collapsed]/sidebar:w-0 group-data-[state=collapsed]/sidebar:hidden transition-all duration-200",
+                            **{"data-label": "true"}
+                        ),
+                        modifier=ad.ButtonMods.secondary,
+                        class_=(
+                            "flex items-center transition-all duration-200 rounded-lg "
+                            "w-full h-11 justify-start px-2 border border-gray-300 "
+                            "group-data-[state=collapsed]/sidebar:w-9 group-data-[state=collapsed]/sidebar:h-9 "
+                            "group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0 "
+                            "group-data-[state=collapsed]/sidebar:border-transparent"
+                        ),
                         id="new-chat-btn",
                         type="button",
                         **{"aria-label": "Nueva conversación"}
                     ),
-                    class_="sidebar-actions"
+                    class_="flex justify-center px-2 py-3 shrink-0"
                 ),
                 
                 # Main content area (only visible when expanded)
@@ -182,56 +213,73 @@ class ConversationCard:
                         air.Input(
                             type="search",
                             placeholder="Buscar...",
-                            class_="history-search-input",
+                            class_="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg bg-white focus:outline-none focus:border-indigo-500",
                             id="history-search",
                             **{"aria-label": "Buscar conversaciones"}
                         ),
-                        class_="history-search-container"
+                        class_="px-4 mb-2"
                     ),
                     
                     # Section title
-                    air.Div("Recientes", class_="history-section-title"),
+                    air.Div(
+                        "Recientes",
+                        class_="px-4 py-2 text-sm font-semibold text-gray-700"
+                    ),
                     
                     # Scrollable history list
                     air.Div(
                         *conversation_groups,
-                        class_="history-scroll-area",
+                        class_="flex-1 overflow-y-auto pr-1",
                         id="history-list"
                     ),
                     
-                    class_="sidebar-main-content"
+                    id="sidebar-main-content",
+                    class_="flex-1 flex flex-col overflow-hidden transition-opacity duration-200 group-data-[state=collapsed]/sidebar:hidden"
                 ),
                 
                 # Footer with settings
                 air.Div(
-                    air.Button(
-                        air.Raw(ICON_SETTINGS),
-                        air.Span("Configuración", class_="sidebar-label"),
-                        class_="sidebar-footer-btn",
+                    ad.Button(
+                        air.Raw(_icon("settings", 20)),
+                        air.Span(
+                            "Configuración",
+                            class_="ml-3 text-sm whitespace-nowrap opacity-100 group-data-[state=collapsed]/sidebar:opacity-0 group-data-[state=collapsed]/sidebar:w-0 group-data-[state=collapsed]/sidebar:hidden transition-all duration-200",
+                            **{"data-label": "true"}
+                        ),
+                        modifier=ad.ButtonMods.ghost,
+                        class_=(
+                            "flex items-center transition-colors "
+                            "w-full justify-start px-2 "
+                            "group-data-[state=collapsed]/sidebar:w-9 group-data-[state=collapsed]/sidebar:h-9 "
+                            "group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0 "
+                            "group-data-[state=collapsed]/sidebar:border group-data-[state=collapsed]/sidebar:border-transparent"
+                        ),
                         id="settings-btn",
                         type="button",
                         **{"aria-label": "Configuración"}
                     ),
-                    class_="sidebar-footer"
+                    class_="flex justify-center px-2 py-3 border-t border-gray-200 mt-auto shrink-0"
                 ),
                 
-                class_="sidebar-inner-col"
+                class_="flex flex-col h-full w-full"
             ),
             
-            class_=f"sidebar{expanded_class}",
-            id="history-sidebar"
+            class_=f"{sidebar_base} w-[380px] min-w-[380px] data-[state=collapsed]:w-[52px] data-[state=collapsed]:min-w-[52px] group/sidebar",
+            id="history-sidebar",
+            **{"data-state": "expanded" if expanded else "collapsed"}
         )
     
     @staticmethod
-    def create_mobile_toggle() -> air.Button:
+    def create_mobile_toggle() -> ad.Button:
         """Create the mobile toggle button (visible only on small screens).
         
         Returns:
-            Air Button component for mobile sidebar toggle
+            AirDragon Button component for mobile sidebar toggle
         """
-        return air.Button(
-            air.Raw(ICON_MENU),
-            class_="mobile-toggle",
+        return ad.Button(
+            air.Raw(_icon("menu", 20)),
+            modifier=ad.ButtonMods.ghost,
+            class_="fixed top-[88px] left-3 w-10 h-10 md:hidden shadow-lg z-40",
             id="mobile-sidebar-toggle",
             type="button",
             **{"aria-label": "Abrir menú lateral"}
@@ -245,6 +293,6 @@ class ConversationCard:
             Air Div component for the overlay
         """
         return air.Div(
-            class_="sidebar-overlay",
+            class_="fixed inset-0 bg-black bg-opacity-30 z-40 hidden",
             id="sidebar-overlay"
         )

--- a/pages/conversation_new.py
+++ b/pages/conversation_new.py
@@ -7,24 +7,17 @@ from ui.button import Button
 from ui.card import Card
 from ui.form import Form
 from components.chat_message import ChatMessage
+from components.conversation_card import ConversationCard
 
 
 class ConversationNewPage:
     """Page component for new conversation (chat demo)."""
     
     @staticmethod
+    # 1. MANTENEMOS 'user' (De HEAD) porque lo necesitas para Airclerk
     def render(user) -> air.Html:
-        """Render the complete demo chat page using existing CSS classes.
+        """Render the complete demo chat page with sidebar and auth."""
         
-        Uses existing chat.css and context.css for styling.
-        Minimal responsive design without hardcoded styles.
-        
-        Args:
-            user: Authenticated user object from Clerk (Pydantic model)
-        
-        Returns:
-            Air Html component for the demo page
-        """
         user_greeting = f"Hola, {user.first_name or 'Usuario'}"
         
         return air.Html(
@@ -33,14 +26,13 @@ class ConversationNewPage:
                 air.Meta(charset="UTF-8"),
                 air.Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
                 air.Link(rel="stylesheet", href="/static/css/chat.css"),
-                air.Link(rel="stylesheet", href="/static/css/context.css")
+                air.Link(rel="stylesheet", href="/static/css/context.css"),
+                air.Link(rel="stylesheet", href="/static/css/history.css")
             ),
             
             air.Body(
-                # Clerk scripts for authentication sync
                 airclerk.clerk_scripts(user),
                 
-                # User header with logout button
                 air.Div(
                     air.Div(user_greeting),
                     air.Form(
@@ -54,55 +46,75 @@ class ConversationNewPage:
                     ),
                     style="display: flex; justify-content: space-between; padding: 0.5rem 1rem; align-items: center; background: white; border-bottom: 1px solid #dee2e6;"
                 ),
-                
+
                 air.Div(
                     air.H1("DOF Chat Demo"),
                     air.P("Sistema de consultas sobre documentos del Diario Oficial de la Federación"),
                     class_="header"
                 ),
                 
+                # App layout container (sidebar + main content)
                 air.Div(
-                    # Chat window
-                    Card.create(
-                        ChatMessage.welcome_message(
-                            "¡Hola! Soy tu asistente para consultas sobre documentos del DOF. "
-                            "Puedes preguntarme sobre cualquier tema y te ayudaré a encontrar información relevante."
+                    # History sidebar panel
+                    ConversationCard.create_panel(expanded=True),
+                    
+                    # Mobile overlay
+                    ConversationCard.create_overlay(),
+                    
+                    # Main content area
+                    air.Main(
+                        air.Div(
+                            # Chat window
+                            Card.create(
+                                ChatMessage.welcome_message(
+                                    "¡Hola! Soy tu asistente para consultas sobre documentos del DOF. "
+                                    "Puedes preguntarme sobre cualquier tema y te ayudaré a encontrar información relevante."
+                                ),
+                                id="chat-window",
+                                class_="chat-window"
+                            ),
+                            
+                            # Input container
+                            air.Div(
+                                Form.create(
+                                    air.Label(
+                                        "Escribe tu consulta:",
+                                        for_="chat-input",
+                                        class_="sr-only"
+                                    ),
+                                    Input.chat(
+                                        id="chat-input",
+                                        placeholder="Escribe tu pregunta sobre documentos del DOF...",
+                                        required=True,
+                                        **{
+                                            "aria-label": "Campo de texto para consultas sobre documentos del DOF",
+                                            "autocomplete": "off"
+                                        }
+                                    ),
+                                    # Send button
+                                    Button.primary(
+                                        "Enviar",
+                                        type="submit",
+                                        id="send-button"
+                                    ),
+                                    id="chat-form"
+                                ),
+                                class_="input-container"
+                            ),
+                            
+                            class_="chat-container"
                         ),
-                        id="chat-window",
-                        class_="chat-window"
+                        class_="main-content"
                     ),
                     
-                    air.Div(
-                        Form.create(
-                            air.Label(
-                                "Escribe tu consulta:",
-                                for_="chat-input",
-                                class_="sr-only"
-                            ),
-                            Input.chat(
-                                id="chat-input",
-                                placeholder="Escribe tu pregunta sobre documentos del DOF...",
-                                required=True,
-                                **{
-                                    "aria-label": "Campo de texto para consultas sobre documentos del DOF",
-                                    "autocomplete": "off"
-                                }
-                            ),
-                            # Send button
-                            Button.primary(
-                                "Enviar",
-                                type="submit",
-                                id="send-button"
-                            ),
-                            id="chat-form"
-                        ),
-                        class_="input-container"
-                    ),
-                    
-                    class_="chat-container"
+                    class_="app-layout"
                 ),
                 
-                # JavaScript for chat functionality
-                air.Script(src="/static/js/chat.js")
+                # Mobile toggle button
+                ConversationCard.create_mobile_toggle(),
+                
+                # JavaScript for chat and history functionality
+                air.Script(src="/static/js/chat.js"),
+                air.Script(src="/static/js/history.js")
             )
         )

--- a/pages/conversation_new.py
+++ b/pages/conversation_new.py
@@ -14,7 +14,6 @@ class ConversationNewPage:
     """Page component for new conversation (chat demo)."""
     
     @staticmethod
-    # 1. MANTENEMOS 'user' (De HEAD) porque lo necesitas para Airclerk
     def render(user) -> air.Html:
         """Render the complete demo chat page with sidebar and auth."""
         

--- a/pages/conversation_new.py
+++ b/pages/conversation_new.py
@@ -65,6 +65,7 @@ class ConversationNewPage:
                     
                     # Main content area
                     air.Main(
+                        # Chat container (visible by default)
                         air.Div(
                             # Chat window
                             Card.create(
@@ -104,8 +105,13 @@ class ConversationNewPage:
                                 class_="input-container"
                             ),
                             
-                            class_="chat-container"
+                            class_="chat-container",
+                            id="chat-container"
                         ),
+                        
+                        # Search view (hidden by default, replaces chat)
+                        ConversationCard.create_search_view(),
+                        
                         class_="main-content"
                     ),
                     

--- a/pages/conversation_new.py
+++ b/pages/conversation_new.py
@@ -27,7 +27,9 @@ class ConversationNewPage:
                 air.Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
                 air.Link(rel="stylesheet", href="/static/css/chat.css"),
                 air.Link(rel="stylesheet", href="/static/css/context.css"),
-                air.Link(rel="stylesheet", href="/static/css/history.css")
+                air.Link(rel="stylesheet", href="/static/css/history.css"),
+                # Tailwind CSS CDN for utility classes in sidebar
+                air.Script(src="https://cdn.tailwindcss.com")
             ),
             
             air.Body(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
     "python-dotenv>=1.2.1",
     "sentence-transformers>=5.1.2",
     "torch>=2.9.0",
+    "airdragon>=0.4.0",
 ]

--- a/rag_service.py
+++ b/rag_service.py
@@ -278,12 +278,11 @@ NOTA: Esta es una respuesta simulada para pruebas de integración. En el modo de
             doc = doc_map[doc_id]
             title = doc.title or f"Documento {doc.id}"
             
-            # Format date for display (age metadata to be calculated later)
-            pub_date = doc.created_at.isoformat() if doc.created_at else None
-            age_desc = None
-            age_emoji = None
+            # Extract publication date and age info from title (DDMMAAAA format)
+            pub_date, age_desc, age_emoji = extract_date_from_title(title)
             
             url = doc.url
+
 
             doc_source = DocumentSource(
                 title=title,

--- a/static/css/history.css
+++ b/static/css/history.css
@@ -61,3 +61,8 @@
         display: block !important;
     }
 }
+
+/* Hide results that don't match search */
+[data-search-result][data-hidden="true"] {
+    display: none;
+}

--- a/static/css/history.css
+++ b/static/css/history.css
@@ -1,422 +1,17 @@
-/* History Panel Styles - Sidebar minimalista */
+/* History Panel Styles - Minimal CSS with AirDragon/Tailwind */
 
-/* Usa las variables de chat.css */
 :root {
-    --sidebar-width: 380px;
-    --sidebar-collapsed-width: 52px;
-    --sidebar-bg: var(--background-fill-secondary, #f8f9fa);
-    --sidebar-border: var(--border-color-primary, #dee2e6);
-    --sidebar-text: var(--body-text-color, #333333);
-    --sidebar-text-muted: var(--body-text-color-subdued, #6c757d);
-    --sidebar-hover: var(--border-color-accent, #e9ecef);
-    --sidebar-active: var(--color-accent, #667eea);
-    --sidebar-transition: 0.25s ease;
+    --header-height: 76px;
 }
 
-/* === LAYOUT PRINCIPAL === */
+/* Main layout */
 .app-layout {
     display: flex;
-    height: calc(100vh - 76px); /* Resta altura del header principal */
+    height: calc(100vh - var(--header-height));
     overflow: hidden;
 }
 
-/* === SIDEBAR CONTENEDOR (FUSIÓN) === */
-.sidebar {
-    width: var(--sidebar-collapsed-width);
-    min-width: var(--sidebar-collapsed-width);
-    height: 100%;
-    background: var(--sidebar-bg);
-    border-right: 1px solid var(--sidebar-border);
-    transition: width var(--sidebar-transition), min-width var(--sidebar-transition);
-    overflow: hidden;
-    z-index: 50;
-    display: flex;
-    flex-direction: column;
-}
-
-.sidebar.expanded {
-    width: var(--sidebar-width);
-    min-width: var(--sidebar-width);
-}
-
-/* Contenedor interno para estructura Flex Vertical */
-.sidebar-inner-col {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    width: 100%;
-}
-
-/* === HEADER Y TOGGLE === */
-.sidebar-header {
-    display: flex;
-    align-items: center;
-    padding: 12px 0 0 8px; /* Centrado visualmente con la columna de iconos colapsada */
-    height: 48px;
-    flex-shrink: 0;
-}
-
-/* Botones de icono estándar */
-.sidebar-icon-btn {
-    width: 36px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    border-radius: 50%; /* Circular para iconos puros */
-    color: var(--sidebar-text-muted);
-    cursor: pointer;
-    transition: all 0.15s ease;
-    flex-shrink: 0; /* No encoger */
-}
-
-.sidebar-icon-btn:hover {
-    background: var(--sidebar-hover);
-    color: var(--sidebar-text);
-}
-
-.sidebar-icon-btn svg {
-    width: 20px;
-    height: 20px;
-}
-
-/* === BOTÓN NUEVA CONVERSACIÓN (TRANSFORMABLE) === */
-.sidebar-actions {
-    padding: 16px 8px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start; /* Alineado a la izquierda */
-    flex-shrink: 0;
-}
-
-.new-chat-btn {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    border: none;
-    color: var(--sidebar-text);
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    overflow: hidden;
-    
-    /* Estado Colapsado (Default) */
-    width: 36px;
-    height: 36px;
-    justify-content: center;
-    background: transparent;
-    border-radius: 50%;
-    color: var(--sidebar-text-muted);
-}
-
-.new-chat-btn svg {
-    width: 20px;
-    height: 20px;
-    min-width: 20px; /* Prevenir aplastamiento */
-}
-
-.new-chat-btn:hover {
-    background: var(--sidebar-hover);
-}
-
-/* Estado Expandido - Botón estilo 'Pill' */
-.sidebar.expanded .new-chat-btn {
-    width: 100%;
-    height: 44px;
-    justify-content: flex-start;
-    padding: 0 16px;
-    border-radius: 8px; /* Square pero suave */
-    background: var(--sidebar-hover); /* Fondo gris suave */
-    color: var(--sidebar-text);
-}
-
-.sidebar.expanded .new-chat-btn:hover {
-    background: #e2e6ea; /* Un poco más oscuro */
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-
-/* Texto de etiquetas (oculto en colapsado) */
-.sidebar-label {
-    opacity: 0;
-    width: 0;
-    margin-left: 0;
-    display: none;
-    transition: opacity 0.2s ease;
-}
-
-.sidebar.expanded .sidebar-label {
-    display: inline-block;
-    opacity: 1;
-    width: auto;
-    margin-left: 12px;
-    font-size: 0.9rem;
-    font-weight: 500;
-}
-
-/* === CONTENIDO PRINCIPAL (LISTA E HISTORIAL) === */
-.sidebar-main-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden; /* Ocultar scrollbars cuando colapsado */
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.2s ease, visibility 0.2s;
-    padding: 0 12px;
-}
-
-/* Solo visible cuando expandido */
-.sidebar.expanded .sidebar-main-content {
-    opacity: 1;
-    visibility: visible;
-    transition-delay: 0.1s; /* Esperar un poco a que abra */
-}
-
-/* Header de "Recientes" */
-.history-section-title {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--sidebar-text);
-    margin: 16px 4px 8px 4px;
-}
-
-/* Area de scroll */
-.history-scroll-area {
-    flex: 1;
-    overflow-y: auto;
-    padding-right: 4px; /* Espacio para scrollbar */
-}
-
-/* === FOOTER === */
-.sidebar-footer {
-    margin-top: auto;
-    padding: 12px 8px;
-    flex-shrink: 0;
-    border-top: 1px solid transparent; /* Opcional divider */
-}
-
-/* Botones footer que se expanden */
-.sidebar-footer-btn {
-    width: 36px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    color: var(--sidebar-text-muted);
-    cursor: pointer;
-    transition: all 0.15s ease;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.sidebar-footer-btn svg {
-    width: 20px;
-    height: 20px;
-    min-width: 20px;
-}
-
-.sidebar.expanded .sidebar-footer-btn {
-    width: 100%;
-    justify-content: flex-start;
-    padding: 0 12px;
-    border-radius: 6px;
-}
-
-.sidebar-footer-btn:hover {
-    background: var(--sidebar-hover);
-    color: var(--sidebar-text);
-}
-
-/* === ESTILOS ANTERIORES PRESERVADOS (ITEMS, SCROLLBARS) === */
-/* ... (Search input styling) */
-/* === ESTILOS DEL MENU DE 3 PUNTOS === */
-.history-item-actions-container {
-    position: relative;
-    opacity: 0;
-    transition: opacity 0.15s ease;
-}
-
-.history-item:hover .history-item-actions-container {
-    opacity: 1;
-}
-
-/* Botón trigger (3 puntos) */
-.history-menu-trigger {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    border: none;
-    background: transparent;
-    color: var(--sidebar-text-muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background 0.15s ease, color 0.15s ease;
-}
-
-.history-menu-trigger:hover {
-    background: var(--sidebar-hover);
-    color: var(--sidebar-text);
-}
-
-.history-menu-trigger svg {
-    width: 18px;
-    height: 18px;
-}
-
-/* Dropdown Menu (Popover) */
-.history-dropdown-menu {
-    position: absolute;
-    right: 0;
-    top: 32px; /* Justo debajo del trigger */
-    background: var(--background-fill-primary);
-    border: 1px solid var(--sidebar-border);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    padding: 4px;
-    z-index: 100;
-    min-width: 140px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.history-dropdown-menu.hidden {
-    display: none;
-}
-
-/* Items del menu */
-.history-menu-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 8px 12px;
-    text-align: left;
-    background: transparent;
-    border: none;
-    border-radius: 4px;
-    font-size: 0.85rem;
-    color: var(--sidebar-text);
-    cursor: pointer;
-    transition: background 0.15s ease;
-}
-
-.history-menu-item:hover {
-    background: var(--sidebar-hover);
-}
-
-.history-menu-item.delete {
-    color: #ef4444; /* Red color manually just in case var is missing */
-}
-
-.history-menu-item.delete:hover {
-    background: #fef2f2;
-    color: #dc2626;
-}
-
-/* Iconos dentro del menu */
-.menu-item-icon svg {
-    width: 16px;
-    height: 16px;
-    opacity: 0.7;
-}
-
-/* Ajustar el espadiado de items del historial ("Breathing room") */
-.history-item {
-    display: flex;
-    align-items: flex-start;
-    padding: 10px 12px; /* Aumentado padding vertical */
-    margin-bottom: 2px;
-    cursor: pointer;
-    border-radius: 8px;
-    transition: background 0.15s ease;
-    position: relative;
-}
-
-/* Asegurar que el título no se solape con el menú */
-.history-item-content {
-    flex: 1;
-    min-width: 0; /* Text truncation fix */
-    margin-right: 8px;
-}
-
-/* === RESTO DE ESTILOS === */
-.history-search-container {
-    margin-bottom: 8px;
-}
-
-.history-search-input {
-    width: 100%;
-    padding: 8px 12px;
-    border: 1px solid var(--sidebar-border);
-    border-radius: 8px; /* Square pero suave */
-    background: var(--background-fill-primary);
-    font-size: 0.9rem;
-}
-/* === GRUPOS POR FECHA === */
-.history-group {
-    margin-bottom: 8px;
-}
-
-.history-group:empty {
-    display: none;
-}
-
-.history-group-title {
-    padding: 8px 8px 4px;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    color: var(--sidebar-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-/* === ITEMS DE CONVERSACIÓN === */
-.history-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 10px;
-    border-radius: var(--radius-md, 6px);
-    cursor: pointer;
-    transition: background 0.15s;
-    margin-bottom: 2px;
-}
-
-.history-item:hover {
-    background: var(--sidebar-hover);
-}
-
-.history-item.active {
-    background: var(--sidebar-hover);
-    border-left: 3px solid var(--sidebar-active);
-    padding-left: 7px;
-}
-
-.history-item-content {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.history-item-title {
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--sidebar-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-/* === CONTENIDO PRINCIPAL === */
+/* Main content area */
 .main-content {
     flex: 1;
     display: flex;
@@ -425,126 +20,44 @@
     background: #f5f5f5;
 }
 
-/* Ajuste del chat-container dentro del layout */
-.main-content .chat-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 1rem;
-    width: 100%;
+/* Smooth scrollbar styling */
+.overflow-y-auto::-webkit-scrollbar {
+    width: 6px;
 }
 
-/* === ESTADOS VACÍOS === */
-.history-empty {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 24px 16px;
-    text-align: center;
-    color: var(--sidebar-text-muted);
+.overflow-y-auto::-webkit-scrollbar-track {
+    background: transparent;
 }
 
-.history-empty-text {
-    font-size: 0.8125rem;
+.overflow-y-auto::-webkit-scrollbar-thumb {
+    background: #cbd5e0;
+    border-radius: 3px;
 }
 
-.history-no-results {
-    padding: 16px;
-    text-align: center;
-    color: var(--sidebar-text-muted);
-    font-size: 0.8125rem;
+.overflow-y-auto::-webkit-scrollbar-thumb:hover {
+    background: #a0aec0;
 }
 
-/* === RESPONSIVE === */
-@media (max-width: 768px) {
-    .sidebar {
-        position: fixed;
-        top: 76px;
-        left: 0;
-        height: calc(100vh - 76px);
-        transform: translateX(calc(-1 * var(--sidebar-width)));
-        width: var(--sidebar-width);
-        min-width: var(--sidebar-width);
-        box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-        z-index: 100;
-    }
-    
-    .sidebar.expanded {
-        transform: translateX(0);
-    }
-    
-    .sidebar-icons {
-        display: none;
-    }
-    
-    .sidebar.expanded .history-panel {
-        width: 100%;
-    }
-    
-    /* Botón flotante móvil */
-    .mobile-toggle {
-        display: flex;
-    }
-    
-    .main-content {
-        width: 100%;
-    }
-    
-    /* Overlay móvil */
-    .sidebar-overlay {
-        display: none;
-        position: fixed;
-        top: 76px;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.3);
-        z-index: 99;
-    }
-    
-    .sidebar-overlay.visible {
-        display: block;
-    }
-}
-
-/* Botón flotante móvil (oculto en desktop) */
-.mobile-toggle {
-    display: none;
-    position: fixed;
-    top: 88px;
-    left: 12px;
-    width: 40px;
-    height: 40px;
-    background: var(--background-fill-primary);
-    border: 1px solid var(--sidebar-border);
-    border-radius: var(--radius-md, 6px);
-    color: var(--sidebar-text);
-    cursor: pointer;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    z-index: 98;
-}
-
-.mobile-toggle:hover {
-    background: var(--sidebar-hover);
-}
-
-@media (max-width: 768px) {
-    .mobile-toggle {
-        display: flex;
-    }
-}
-
-/* === ANIMACIONES === */
+/* Fade in animation for conversation items */
 @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
-.history-item {
-    animation: fadeIn 0.15s ease-out;
+[data-conversation-id] {
+    animation: fadeIn 0.2s ease-out;
+}
+
+/* Responsive - Mobile overlay visibility */
+@media (max-width: 768px) {
+    #sidebar-overlay.visible {
+        display: block !important;
+    }
 }

--- a/static/css/history.css
+++ b/static/css/history.css
@@ -1,0 +1,550 @@
+/* History Panel Styles - Sidebar minimalista */
+
+/* Usa las variables de chat.css */
+:root {
+    --sidebar-width: 380px;
+    --sidebar-collapsed-width: 52px;
+    --sidebar-bg: var(--background-fill-secondary, #f8f9fa);
+    --sidebar-border: var(--border-color-primary, #dee2e6);
+    --sidebar-text: var(--body-text-color, #333333);
+    --sidebar-text-muted: var(--body-text-color-subdued, #6c757d);
+    --sidebar-hover: var(--border-color-accent, #e9ecef);
+    --sidebar-active: var(--color-accent, #667eea);
+    --sidebar-transition: 0.25s ease;
+}
+
+/* === LAYOUT PRINCIPAL === */
+.app-layout {
+    display: flex;
+    height: calc(100vh - 76px); /* Resta altura del header principal */
+    overflow: hidden;
+}
+
+/* === SIDEBAR CONTENEDOR (FUSIÓN) === */
+.sidebar {
+    width: var(--sidebar-collapsed-width);
+    min-width: var(--sidebar-collapsed-width);
+    height: 100%;
+    background: var(--sidebar-bg);
+    border-right: 1px solid var(--sidebar-border);
+    transition: width var(--sidebar-transition), min-width var(--sidebar-transition);
+    overflow: hidden;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar.expanded {
+    width: var(--sidebar-width);
+    min-width: var(--sidebar-width);
+}
+
+/* Contenedor interno para estructura Flex Vertical */
+.sidebar-inner-col {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+/* === HEADER Y TOGGLE === */
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 0 0 8px; /* Centrado visualmente con la columna de iconos colapsada */
+    height: 48px;
+    flex-shrink: 0;
+}
+
+/* Botones de icono estándar */
+.sidebar-icon-btn {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 50%; /* Circular para iconos puros */
+    color: var(--sidebar-text-muted);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    flex-shrink: 0; /* No encoger */
+}
+
+.sidebar-icon-btn:hover {
+    background: var(--sidebar-hover);
+    color: var(--sidebar-text);
+}
+
+.sidebar-icon-btn svg {
+    width: 20px;
+    height: 20px;
+}
+
+/* === BOTÓN NUEVA CONVERSACIÓN (TRANSFORMABLE) === */
+.sidebar-actions {
+    padding: 16px 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start; /* Alineado a la izquierda */
+    flex-shrink: 0;
+}
+
+.new-chat-btn {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    border: none;
+    color: var(--sidebar-text);
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    overflow: hidden;
+    
+    /* Estado Colapsado (Default) */
+    width: 36px;
+    height: 36px;
+    justify-content: center;
+    background: transparent;
+    border-radius: 50%;
+    color: var(--sidebar-text-muted);
+}
+
+.new-chat-btn svg {
+    width: 20px;
+    height: 20px;
+    min-width: 20px; /* Prevenir aplastamiento */
+}
+
+.new-chat-btn:hover {
+    background: var(--sidebar-hover);
+}
+
+/* Estado Expandido - Botón estilo 'Pill' */
+.sidebar.expanded .new-chat-btn {
+    width: 100%;
+    height: 44px;
+    justify-content: flex-start;
+    padding: 0 16px;
+    border-radius: 8px; /* Square pero suave */
+    background: var(--sidebar-hover); /* Fondo gris suave */
+    color: var(--sidebar-text);
+}
+
+.sidebar.expanded .new-chat-btn:hover {
+    background: #e2e6ea; /* Un poco más oscuro */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+/* Texto de etiquetas (oculto en colapsado) */
+.sidebar-label {
+    opacity: 0;
+    width: 0;
+    margin-left: 0;
+    display: none;
+    transition: opacity 0.2s ease;
+}
+
+.sidebar.expanded .sidebar-label {
+    display: inline-block;
+    opacity: 1;
+    width: auto;
+    margin-left: 12px;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+/* === CONTENIDO PRINCIPAL (LISTA E HISTORIAL) === */
+.sidebar-main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden; /* Ocultar scrollbars cuando colapsado */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s;
+    padding: 0 12px;
+}
+
+/* Solo visible cuando expandido */
+.sidebar.expanded .sidebar-main-content {
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0.1s; /* Esperar un poco a que abra */
+}
+
+/* Header de "Recientes" */
+.history-section-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--sidebar-text);
+    margin: 16px 4px 8px 4px;
+}
+
+/* Area de scroll */
+.history-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 4px; /* Espacio para scrollbar */
+}
+
+/* === FOOTER === */
+.sidebar-footer {
+    margin-top: auto;
+    padding: 12px 8px;
+    flex-shrink: 0;
+    border-top: 1px solid transparent; /* Opcional divider */
+}
+
+/* Botones footer que se expanden */
+.sidebar-footer-btn {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--sidebar-text-muted);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.sidebar-footer-btn svg {
+    width: 20px;
+    height: 20px;
+    min-width: 20px;
+}
+
+.sidebar.expanded .sidebar-footer-btn {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0 12px;
+    border-radius: 6px;
+}
+
+.sidebar-footer-btn:hover {
+    background: var(--sidebar-hover);
+    color: var(--sidebar-text);
+}
+
+/* === ESTILOS ANTERIORES PRESERVADOS (ITEMS, SCROLLBARS) === */
+/* ... (Search input styling) */
+/* === ESTILOS DEL MENU DE 3 PUNTOS === */
+.history-item-actions-container {
+    position: relative;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.history-item:hover .history-item-actions-container {
+    opacity: 1;
+}
+
+/* Botón trigger (3 puntos) */
+.history-menu-trigger {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--sidebar-text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.history-menu-trigger:hover {
+    background: var(--sidebar-hover);
+    color: var(--sidebar-text);
+}
+
+.history-menu-trigger svg {
+    width: 18px;
+    height: 18px;
+}
+
+/* Dropdown Menu (Popover) */
+.history-dropdown-menu {
+    position: absolute;
+    right: 0;
+    top: 32px; /* Justo debajo del trigger */
+    background: var(--background-fill-primary);
+    border: 1px solid var(--sidebar-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    padding: 4px;
+    z-index: 100;
+    min-width: 140px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.history-dropdown-menu.hidden {
+    display: none;
+}
+
+/* Items del menu */
+.history-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 12px;
+    text-align: left;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    color: var(--sidebar-text);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.history-menu-item:hover {
+    background: var(--sidebar-hover);
+}
+
+.history-menu-item.delete {
+    color: #ef4444; /* Red color manually just in case var is missing */
+}
+
+.history-menu-item.delete:hover {
+    background: #fef2f2;
+    color: #dc2626;
+}
+
+/* Iconos dentro del menu */
+.menu-item-icon svg {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+}
+
+/* Ajustar el espadiado de items del historial ("Breathing room") */
+.history-item {
+    display: flex;
+    align-items: flex-start;
+    padding: 10px 12px; /* Aumentado padding vertical */
+    margin-bottom: 2px;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background 0.15s ease;
+    position: relative;
+}
+
+/* Asegurar que el título no se solape con el menú */
+.history-item-content {
+    flex: 1;
+    min-width: 0; /* Text truncation fix */
+    margin-right: 8px;
+}
+
+/* === RESTO DE ESTILOS === */
+.history-search-container {
+    margin-bottom: 8px;
+}
+
+.history-search-input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--sidebar-border);
+    border-radius: 8px; /* Square pero suave */
+    background: var(--background-fill-primary);
+    font-size: 0.9rem;
+}
+/* === GRUPOS POR FECHA === */
+.history-group {
+    margin-bottom: 8px;
+}
+
+.history-group:empty {
+    display: none;
+}
+
+.history-group-title {
+    padding: 8px 8px 4px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--sidebar-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+/* === ITEMS DE CONVERSACIÓN === */
+.history-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: var(--radius-md, 6px);
+    cursor: pointer;
+    transition: background 0.15s;
+    margin-bottom: 2px;
+}
+
+.history-item:hover {
+    background: var(--sidebar-hover);
+}
+
+.history-item.active {
+    background: var(--sidebar-hover);
+    border-left: 3px solid var(--sidebar-active);
+    padding-left: 7px;
+}
+
+.history-item-content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.history-item-title {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--sidebar-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* === CONTENIDO PRINCIPAL === */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: #f5f5f5;
+}
+
+/* Ajuste del chat-container dentro del layout */
+.main-content .chat-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1rem;
+    width: 100%;
+}
+
+/* === ESTADOS VACÍOS === */
+.history-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--sidebar-text-muted);
+}
+
+.history-empty-text {
+    font-size: 0.8125rem;
+}
+
+.history-no-results {
+    padding: 16px;
+    text-align: center;
+    color: var(--sidebar-text-muted);
+    font-size: 0.8125rem;
+}
+
+/* === RESPONSIVE === */
+@media (max-width: 768px) {
+    .sidebar {
+        position: fixed;
+        top: 76px;
+        left: 0;
+        height: calc(100vh - 76px);
+        transform: translateX(calc(-1 * var(--sidebar-width)));
+        width: var(--sidebar-width);
+        min-width: var(--sidebar-width);
+        box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+        z-index: 100;
+    }
+    
+    .sidebar.expanded {
+        transform: translateX(0);
+    }
+    
+    .sidebar-icons {
+        display: none;
+    }
+    
+    .sidebar.expanded .history-panel {
+        width: 100%;
+    }
+    
+    /* Botón flotante móvil */
+    .mobile-toggle {
+        display: flex;
+    }
+    
+    .main-content {
+        width: 100%;
+    }
+    
+    /* Overlay móvil */
+    .sidebar-overlay {
+        display: none;
+        position: fixed;
+        top: 76px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.3);
+        z-index: 99;
+    }
+    
+    .sidebar-overlay.visible {
+        display: block;
+    }
+}
+
+/* Botón flotante móvil (oculto en desktop) */
+.mobile-toggle {
+    display: none;
+    position: fixed;
+    top: 88px;
+    left: 12px;
+    width: 40px;
+    height: 40px;
+    background: var(--background-fill-primary);
+    border: 1px solid var(--sidebar-border);
+    border-radius: var(--radius-md, 6px);
+    color: var(--sidebar-text);
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    z-index: 98;
+}
+
+.mobile-toggle:hover {
+    background: var(--sidebar-hover);
+}
+
+@media (max-width: 768px) {
+    .mobile-toggle {
+        display: flex;
+    }
+}
+
+/* === ANIMACIONES === */
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.history-item {
+    animation: fadeIn 0.15s ease-out;
+}

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -11,13 +11,19 @@ class HistoryPanel {
             mobileToggle: document.getElementById('mobile-sidebar-toggle'),
             overlay: document.getElementById('sidebar-overlay'),
             newChatBtn: document.getElementById('new-chat-btn'),
-            searchInput: document.getElementById('history-search'),
             historyList: document.getElementById('history-list'),
-            settingsBtn: document.getElementById('settings-btn')
+            settingsBtn: document.getElementById('settings-btn'),
+            // Search view elements (inline, replaces chat)
+            searchTrigger: document.getElementById('search-trigger'),
+            searchView: document.getElementById('search-view'),
+            searchInput: document.getElementById('search-input'),
+            searchResults: document.getElementById('search-results'),
+            chatContainer: document.getElementById('chat-container')
         };
 
         this.initializeEventListeners();
         this.initializeDropdownMenus();
+        this.initializeSearchView();
     }
 
     initializeEventListeners() {
@@ -46,13 +52,6 @@ class HistoryPanel {
         if (this.elements.newChatBtn) {
             this.elements.newChatBtn.addEventListener('click', () => {
                 this.handleNewConversation();
-            });
-        }
-
-        // Search input
-        if (this.elements.searchInput) {
-            this.elements.searchInput.addEventListener('input', (e) => {
-                this.handleSearch(e.target.value);
             });
         }
 
@@ -86,9 +85,18 @@ class HistoryPanel {
 
         // Keyboard shortcuts
         document.addEventListener('keydown', (e) => {
-            // Escape to close sidebar on mobile
-            if (e.key === 'Escape' && this.isMobile() && this.isSidebarExpanded()) {
-                this.closeSidebar();
+            // Escape to close search view or sidebar on mobile
+            if (e.key === 'Escape') {
+                if (this.isSearchViewOpen()) {
+                    this.closeSearchView();
+                } else if (this.isMobile() && this.isSidebarExpanded()) {
+                    this.closeSidebar();
+                }
+            }
+            // Ctrl+K to open search view
+            if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+                e.preventDefault();
+                this.toggleSearchView();
             }
         });
     }
@@ -137,6 +145,92 @@ class HistoryPanel {
 
             this.closeAllDropdowns();
         });
+    }
+
+    initializeSearchView() {
+        // Open search view on trigger click
+        if (this.elements.searchTrigger) {
+            this.elements.searchTrigger.addEventListener('click', () => {
+                this.toggleSearchView();
+            });
+        }
+
+        // Search input filtering
+        if (this.elements.searchInput) {
+            this.elements.searchInput.addEventListener('input', (e) => {
+                this.handleSearch(e.target.value);
+            });
+        }
+
+        // Result click handling
+        if (this.elements.searchResults) {
+            this.elements.searchResults.addEventListener('click', (e) => {
+                const result = e.target.closest('[data-search-result]');
+                if (result) {
+                    const conversationId = result.dataset.conversationId;
+                    this.handleSearchResultClick(conversationId);
+                }
+            });
+        }
+    }
+
+    openSearchView() {
+        if (!this.elements.searchView || !this.elements.chatContainer) return;
+        this.elements.chatContainer.classList.add('hidden');
+        this.elements.searchView.classList.remove('hidden');
+        // Focus input
+        setTimeout(() => {
+            this.elements.searchInput?.focus();
+        }, 50);
+    }
+
+    closeSearchView() {
+        if (!this.elements.searchView || !this.elements.chatContainer) return;
+        this.elements.searchView.classList.add('hidden');
+        this.elements.chatContainer.classList.remove('hidden');
+        // Clear search input
+        if (this.elements.searchInput) {
+            this.elements.searchInput.value = '';
+            this.handleSearch('');
+        }
+    }
+
+    toggleSearchView() {
+        if (this.isSearchViewOpen()) {
+            this.closeSearchView();
+        } else {
+            this.openSearchView();
+        }
+    }
+
+    isSearchViewOpen() {
+        return this.elements.searchView && !this.elements.searchView.classList.contains('hidden');
+    }
+
+    handleSearch(query) {
+        const normalizedQuery = query.toLowerCase().trim();
+        const results = this.elements.searchResults?.querySelectorAll('[data-search-result]');
+
+        results?.forEach(result => {
+            const titleEl = result.querySelector('[data-search-title]');
+            const title = titleEl?.textContent.toLowerCase() || '';
+            const matches = normalizedQuery === '' || title.includes(normalizedQuery);
+            result.dataset.hidden = matches ? 'false' : 'true';
+        });
+    }
+
+    handleSearchResultClick(conversationId) {
+        console.log('Selected from search:', conversationId);
+
+        // Update active state in sidebar
+        this.elements.historyList?.querySelectorAll('[data-conversation-id]').forEach(item => {
+            item.dataset.active = item.dataset.conversationId === conversationId ? 'true' : 'false';
+        });
+
+        // Close the search view and show chat
+        this.closeSearchView();
+
+        // TODO: Load the conversation
     }
 
     toggleSidebar(forceExpand = false) {
@@ -192,26 +286,6 @@ class HistoryPanel {
             const messages = chatWindow.querySelectorAll('.message:not(.assistant):not(:first-child)');
             messages.forEach(msg => msg.remove());
         }
-    }
-
-    handleSearch(query) {
-        const normalizedQuery = query.toLowerCase().trim();
-        const items = this.elements.historyList?.querySelectorAll('[data-conversation-id]');
-        const groups = this.elements.historyList?.querySelectorAll('[data-conversation-group]');
-
-        items?.forEach(item => {
-            // Use semantic selector for title
-            const titleEl = item.querySelector('[data-conversation-title]');
-            const title = titleEl?.textContent.toLowerCase() || '';
-            const matches = title.includes(normalizedQuery);
-            item.style.display = matches ? '' : 'none';
-        });
-
-        // Hide empty groups
-        groups?.forEach(group => {
-            const visibleItems = group.querySelectorAll('[data-conversation-id]:not([style*="display: none"])');
-            group.style.display = visibleItems.length > 0 ? '' : 'none';
-        });
     }
 
     handleConversationClick(item) {

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -1,7 +1,7 @@
 /**
  * History Panel / Sidebar functionality for DOF Chat
- * ChatGPT-style sidebar interactions
  */
+
 class HistoryPanel {
     constructor() {
         // Cache DOM elements
@@ -66,8 +66,12 @@ class HistoryPanel {
         // Conversation item clicks (using event delegation)
         if (this.elements.historyList) {
             this.elements.historyList.addEventListener('click', (e) => {
-                const item = e.target.closest('.history-item');
-                if (item && !e.target.closest('.history-menu-trigger') && !e.target.closest('.history-dropdown-menu')) {
+                // Early return: skip if clicking on menu trigger or dropdown
+                if (e.target.closest('[data-menu-trigger]')) return;
+                if (e.target.closest('[data-dropdown="true"]')) return;
+
+                const item = e.target.closest('[data-conversation-id]');
+                if (item) {
                     this.handleConversationClick(item);
                 }
             });
@@ -75,7 +79,7 @@ class HistoryPanel {
 
         // Close dropdowns when clicking outside
         document.addEventListener('click', (e) => {
-            if (!e.target.closest('.history-item-actions-container')) {
+            if (!e.target.closest('[data-dropdown-container]')) {
                 this.closeAllDropdowns();
             }
         });
@@ -90,14 +94,14 @@ class HistoryPanel {
     }
 
     initializeDropdownMenus() {
-        // Event delegation for dropdown triggers
+        // Event delegation for dropdown triggers - using data-menu-trigger
         document.addEventListener('click', (e) => {
-            const trigger = e.target.closest('.history-menu-trigger');
+            const trigger = e.target.closest('[data-menu-trigger]');
             if (!trigger) return;
 
             e.stopPropagation();
-            const container = trigger.closest('.history-item-actions-container');
-            const dropdown = container?.querySelector('.history-dropdown-menu');
+            const container = trigger.closest('[data-dropdown-container]');
+            const dropdown = container?.querySelector('[data-dropdown="true"]');
 
             if (dropdown) {
                 // Close other dropdowns first
@@ -108,21 +112,27 @@ class HistoryPanel {
 
         // Handle dropdown menu item clicks
         document.addEventListener('click', (e) => {
-            const menuItem = e.target.closest('.history-menu-item');
+            const menuItem = e.target.closest('[data-dropdown="true"] button');
             if (!menuItem) return;
 
             e.stopPropagation();
-            const container = menuItem.closest('.history-item-actions-container');
-            const item = container?.closest('.history-item');
+            const container = menuItem.closest('[data-dropdown-container]');
+            const item = container?.closest('[data-conversation-id]');
             const conversationId = item?.dataset.conversationId;
 
-            if (menuItem.classList.contains('delete')) {
-                this.handleDeleteConversation(conversationId, item);
-            } else if (menuItem.querySelector('.menu-item-icon svg path[d*="M17 3"]')) {
-                // Edit/Rename based on SVG path
-                this.handleRenameConversation(conversationId, item);
-            } else {
-                this.handleShareConversation(conversationId);
+            // Detect action by data-action attribute
+            const action = menuItem.dataset.action;
+
+            switch (action) {
+                case 'delete':
+                    this.handleDeleteConversation(conversationId, item);
+                    break;
+                case 'rename':
+                    this.handleRenameConversation(conversationId, item);
+                    break;
+                case 'share':
+                    this.handleShareConversation(conversationId);
+                    break;
             }
 
             this.closeAllDropdowns();
@@ -132,29 +142,33 @@ class HistoryPanel {
     toggleSidebar(forceExpand = false) {
         if (!this.elements.sidebar) return;
 
-        if (forceExpand) {
-            this.elements.sidebar.classList.add('expanded');
+        const isCurrentlyExpanded = this.elements.sidebar.getAttribute('data-state') === 'expanded';
+
+        if (forceExpand || !isCurrentlyExpanded) {
+            this.elements.sidebar.setAttribute('data-state', 'expanded');
         } else {
-            this.elements.sidebar.classList.toggle('expanded');
+            this.elements.sidebar.setAttribute('data-state', 'collapsed');
         }
 
         // Show/hide overlay on mobile
         if (this.isMobile() && this.elements.overlay) {
-            this.elements.overlay.classList.toggle('visible', this.isSidebarExpanded());
+            this.elements.overlay.classList.toggle('visible', !this.isSidebarExpanded());
         }
     }
 
+
+
     closeSidebar() {
         if (!this.elements.sidebar) return;
-        this.elements.sidebar.classList.remove('expanded');
-        
+        this.elements.sidebar.setAttribute('data-state', 'collapsed');
+
         if (this.elements.overlay) {
             this.elements.overlay.classList.remove('visible');
         }
     }
 
     isSidebarExpanded() {
-        return this.elements.sidebar?.classList.contains('expanded') ?? false;
+        return this.elements.sidebar?.getAttribute('data-state') === 'expanded';
     }
 
     isMobile() {
@@ -162,20 +176,15 @@ class HistoryPanel {
     }
 
     closeAllDropdowns() {
-        document.querySelectorAll('.history-dropdown-menu').forEach(dropdown => {
+        document.querySelectorAll('[data-dropdown="true"]').forEach(dropdown => {
             dropdown.classList.add('hidden');
         });
     }
 
     handleNewConversation() {
-        // For demo purposes, just log the action
+        // TODO: Reset chat state and navigate to new session ID
         console.log('New conversation requested');
-        
-        // In a real app, this would:
-        // 1. Clear the current chat
-        // 2. Reset the conversation state
-        // 3. Optionally redirect to a new conversation page
-        
+
         // Visual feedback
         const chatWindow = document.getElementById('chat-window');
         if (chatWindow) {
@@ -187,19 +196,20 @@ class HistoryPanel {
 
     handleSearch(query) {
         const normalizedQuery = query.toLowerCase().trim();
-        const items = this.elements.historyList?.querySelectorAll('.history-item');
-        const groups = this.elements.historyList?.querySelectorAll('.history-group');
+        const items = this.elements.historyList?.querySelectorAll('[data-conversation-id]');
+        const groups = this.elements.historyList?.querySelectorAll('[data-conversation-group]');
 
         items?.forEach(item => {
-            const title = item.querySelector('.history-item-title')?.textContent.toLowerCase() || '';
-            const preview = item.querySelector('.history-item-preview')?.textContent.toLowerCase() || '';
-            const matches = title.includes(normalizedQuery) || preview.includes(normalizedQuery);
+            // Use semantic selector for title
+            const titleEl = item.querySelector('[data-conversation-title]');
+            const title = titleEl?.textContent.toLowerCase() || '';
+            const matches = title.includes(normalizedQuery);
             item.style.display = matches ? '' : 'none';
         });
 
         // Hide empty groups
         groups?.forEach(group => {
-            const visibleItems = group.querySelectorAll('.history-item:not([style*="display: none"])');
+            const visibleItems = group.querySelectorAll('[data-conversation-id]:not([style*="display: none"])');
             group.style.display = visibleItems.length > 0 ? '' : 'none';
         });
     }
@@ -208,15 +218,17 @@ class HistoryPanel {
         const conversationId = item.dataset.conversationId;
         console.log('Selected conversation:', conversationId);
 
-        // Update active state
-        this.elements.historyList?.querySelectorAll('.history-item').forEach(i => {
-            i.classList.remove('active');
+        // Update active state using data attribute (single source of truth)
+        this.elements.historyList?.querySelectorAll('[data-conversation-id]').forEach(i => {
+            i.dataset.active = 'false';
         });
-        item.classList.add('active');
 
-        // In a real app, this would load the conversation
-        // For demo, just show a message
-        const title = item.querySelector('.history-item-title')?.textContent;
+        // Set selected as active
+        item.dataset.active = 'true';
+
+        // TODO: Fetch and load conversation history from API
+        const titleEl = item.querySelector('[data-conversation-title]');
+        const title = titleEl?.textContent;
         if (title) {
             console.log(`Loading conversation: ${title}`);
         }
@@ -229,13 +241,13 @@ class HistoryPanel {
 
     handleDeleteConversation(conversationId, item) {
         console.log('Delete conversation:', conversationId);
-        
+
         // Animate removal
         if (item) {
-            item.style.transition = 'all 0.2s ease';
+            item.style.transition = `all 200ms ease`;
             item.style.opacity = '0';
             item.style.transform = 'translateX(-10px)';
-            
+
             setTimeout(() => {
                 item.remove();
             }, 200);
@@ -244,13 +256,13 @@ class HistoryPanel {
 
     handleRenameConversation(conversationId, item) {
         console.log('Rename conversation:', conversationId);
-        
-        const titleEl = item?.querySelector('.history-item-title');
+
+        const titleEl = item?.querySelector('[data-conversation-title]');
         if (!titleEl) return;
 
         const currentTitle = titleEl.textContent;
         const newTitle = prompt('Nuevo nombre:', currentTitle);
-        
+
         if (newTitle && newTitle.trim() !== currentTitle) {
             titleEl.textContent = newTitle.trim();
         }
@@ -258,13 +270,13 @@ class HistoryPanel {
 
     handleShareConversation(conversationId) {
         console.log('Share conversation:', conversationId);
-        // In a real app, this would open a share dialog or copy a link
+        // TODO: Implement share dialog modal
         alert('Funcionalidad de compartir próximamente disponible');
     }
 
     handleSettings() {
         console.log('Settings requested');
-        // In a real app, this would open a settings modal or page
+        // TODO: Connect to global settings panel
         alert('Configuración próximamente disponible');
     }
 }

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -1,0 +1,278 @@
+/**
+ * History Panel / Sidebar functionality for DOF Chat
+ * ChatGPT-style sidebar interactions
+ */
+class HistoryPanel {
+    constructor() {
+        // Cache DOM elements
+        this.elements = {
+            sidebar: document.getElementById('history-sidebar'),
+            sidebarToggle: document.getElementById('sidebar-toggle'),
+            mobileToggle: document.getElementById('mobile-sidebar-toggle'),
+            overlay: document.getElementById('sidebar-overlay'),
+            newChatBtn: document.getElementById('new-chat-btn'),
+            searchInput: document.getElementById('history-search'),
+            historyList: document.getElementById('history-list'),
+            settingsBtn: document.getElementById('settings-btn')
+        };
+
+        this.initializeEventListeners();
+        this.initializeDropdownMenus();
+    }
+
+    initializeEventListeners() {
+        // Main sidebar toggle
+        if (this.elements.sidebarToggle) {
+            this.elements.sidebarToggle.addEventListener('click', () => {
+                this.toggleSidebar();
+            });
+        }
+
+        // Mobile toggle button
+        if (this.elements.mobileToggle) {
+            this.elements.mobileToggle.addEventListener('click', () => {
+                this.toggleSidebar(true);
+            });
+        }
+
+        // Overlay click to close sidebar on mobile
+        if (this.elements.overlay) {
+            this.elements.overlay.addEventListener('click', () => {
+                this.closeSidebar();
+            });
+        }
+
+        // New conversation button
+        if (this.elements.newChatBtn) {
+            this.elements.newChatBtn.addEventListener('click', () => {
+                this.handleNewConversation();
+            });
+        }
+
+        // Search input
+        if (this.elements.searchInput) {
+            this.elements.searchInput.addEventListener('input', (e) => {
+                this.handleSearch(e.target.value);
+            });
+        }
+
+        // Settings button
+        if (this.elements.settingsBtn) {
+            this.elements.settingsBtn.addEventListener('click', () => {
+                this.handleSettings();
+            });
+        }
+
+        // Conversation item clicks (using event delegation)
+        if (this.elements.historyList) {
+            this.elements.historyList.addEventListener('click', (e) => {
+                const item = e.target.closest('.history-item');
+                if (item && !e.target.closest('.history-menu-trigger') && !e.target.closest('.history-dropdown-menu')) {
+                    this.handleConversationClick(item);
+                }
+            });
+        }
+
+        // Close dropdowns when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.history-item-actions-container')) {
+                this.closeAllDropdowns();
+            }
+        });
+
+        // Keyboard shortcuts
+        document.addEventListener('keydown', (e) => {
+            // Escape to close sidebar on mobile
+            if (e.key === 'Escape' && this.isMobile() && this.isSidebarExpanded()) {
+                this.closeSidebar();
+            }
+        });
+    }
+
+    initializeDropdownMenus() {
+        // Event delegation for dropdown triggers
+        document.addEventListener('click', (e) => {
+            const trigger = e.target.closest('.history-menu-trigger');
+            if (!trigger) return;
+
+            e.stopPropagation();
+            const container = trigger.closest('.history-item-actions-container');
+            const dropdown = container?.querySelector('.history-dropdown-menu');
+
+            if (dropdown) {
+                // Close other dropdowns first
+                this.closeAllDropdowns();
+                dropdown.classList.toggle('hidden');
+            }
+        });
+
+        // Handle dropdown menu item clicks
+        document.addEventListener('click', (e) => {
+            const menuItem = e.target.closest('.history-menu-item');
+            if (!menuItem) return;
+
+            e.stopPropagation();
+            const container = menuItem.closest('.history-item-actions-container');
+            const item = container?.closest('.history-item');
+            const conversationId = item?.dataset.conversationId;
+
+            if (menuItem.classList.contains('delete')) {
+                this.handleDeleteConversation(conversationId, item);
+            } else if (menuItem.querySelector('.menu-item-icon svg path[d*="M17 3"]')) {
+                // Edit/Rename based on SVG path
+                this.handleRenameConversation(conversationId, item);
+            } else {
+                this.handleShareConversation(conversationId);
+            }
+
+            this.closeAllDropdowns();
+        });
+    }
+
+    toggleSidebar(forceExpand = false) {
+        if (!this.elements.sidebar) return;
+
+        if (forceExpand) {
+            this.elements.sidebar.classList.add('expanded');
+        } else {
+            this.elements.sidebar.classList.toggle('expanded');
+        }
+
+        // Show/hide overlay on mobile
+        if (this.isMobile() && this.elements.overlay) {
+            this.elements.overlay.classList.toggle('visible', this.isSidebarExpanded());
+        }
+    }
+
+    closeSidebar() {
+        if (!this.elements.sidebar) return;
+        this.elements.sidebar.classList.remove('expanded');
+        
+        if (this.elements.overlay) {
+            this.elements.overlay.classList.remove('visible');
+        }
+    }
+
+    isSidebarExpanded() {
+        return this.elements.sidebar?.classList.contains('expanded') ?? false;
+    }
+
+    isMobile() {
+        return window.innerWidth <= 768;
+    }
+
+    closeAllDropdowns() {
+        document.querySelectorAll('.history-dropdown-menu').forEach(dropdown => {
+            dropdown.classList.add('hidden');
+        });
+    }
+
+    handleNewConversation() {
+        // For demo purposes, just log the action
+        console.log('New conversation requested');
+        
+        // In a real app, this would:
+        // 1. Clear the current chat
+        // 2. Reset the conversation state
+        // 3. Optionally redirect to a new conversation page
+        
+        // Visual feedback
+        const chatWindow = document.getElementById('chat-window');
+        if (chatWindow) {
+            // Keep only the welcome message
+            const messages = chatWindow.querySelectorAll('.message:not(.assistant):not(:first-child)');
+            messages.forEach(msg => msg.remove());
+        }
+    }
+
+    handleSearch(query) {
+        const normalizedQuery = query.toLowerCase().trim();
+        const items = this.elements.historyList?.querySelectorAll('.history-item');
+        const groups = this.elements.historyList?.querySelectorAll('.history-group');
+
+        items?.forEach(item => {
+            const title = item.querySelector('.history-item-title')?.textContent.toLowerCase() || '';
+            const preview = item.querySelector('.history-item-preview')?.textContent.toLowerCase() || '';
+            const matches = title.includes(normalizedQuery) || preview.includes(normalizedQuery);
+            item.style.display = matches ? '' : 'none';
+        });
+
+        // Hide empty groups
+        groups?.forEach(group => {
+            const visibleItems = group.querySelectorAll('.history-item:not([style*="display: none"])');
+            group.style.display = visibleItems.length > 0 ? '' : 'none';
+        });
+    }
+
+    handleConversationClick(item) {
+        const conversationId = item.dataset.conversationId;
+        console.log('Selected conversation:', conversationId);
+
+        // Update active state
+        this.elements.historyList?.querySelectorAll('.history-item').forEach(i => {
+            i.classList.remove('active');
+        });
+        item.classList.add('active');
+
+        // In a real app, this would load the conversation
+        // For demo, just show a message
+        const title = item.querySelector('.history-item-title')?.textContent;
+        if (title) {
+            console.log(`Loading conversation: ${title}`);
+        }
+
+        // Close sidebar on mobile after selection
+        if (this.isMobile()) {
+            this.closeSidebar();
+        }
+    }
+
+    handleDeleteConversation(conversationId, item) {
+        console.log('Delete conversation:', conversationId);
+        
+        // Animate removal
+        if (item) {
+            item.style.transition = 'all 0.2s ease';
+            item.style.opacity = '0';
+            item.style.transform = 'translateX(-10px)';
+            
+            setTimeout(() => {
+                item.remove();
+            }, 200);
+        }
+    }
+
+    handleRenameConversation(conversationId, item) {
+        console.log('Rename conversation:', conversationId);
+        
+        const titleEl = item?.querySelector('.history-item-title');
+        if (!titleEl) return;
+
+        const currentTitle = titleEl.textContent;
+        const newTitle = prompt('Nuevo nombre:', currentTitle);
+        
+        if (newTitle && newTitle.trim() !== currentTitle) {
+            titleEl.textContent = newTitle.trim();
+        }
+    }
+
+    handleShareConversation(conversationId) {
+        console.log('Share conversation:', conversationId);
+        // In a real app, this would open a share dialog or copy a link
+        alert('Funcionalidad de compartir próximamente disponible');
+    }
+
+    handleSettings() {
+        console.log('Settings requested');
+        // In a real app, this would open a settings modal or page
+        alert('Configuración próximamente disponible');
+    }
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    // Only initialize if sidebar elements exist
+    if (document.getElementById('history-sidebar')) {
+        new HistoryPanel();
+    }
+});

--- a/static/svg/icons.svg
+++ b/static/svg/icons.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <defs>
+    <!-- ICON_MORE -->
+    <symbol id="icon-more" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/>
+    </symbol>
+
+    <!-- ICON_EDIT -->
+    <symbol id="icon-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/>
+    </symbol>
+
+    <!-- ICON_TRASH -->
+    <symbol id="icon-trash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+    </symbol>
+
+    <!-- ICON_SHARE -->
+    <symbol id="icon-share" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+    </symbol>
+
+    <!-- ICON_MENU -->
+    <symbol id="icon-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/>
+    </symbol>
+
+    <!-- ICON_PLUS -->
+    <symbol id="icon-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+    </symbol>
+
+    <!-- ICON_SETTINGS -->
+    <symbol id="icon-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+    </symbol>
+  </defs>
+</svg>

--- a/static/svg/icons.svg
+++ b/static/svg/icons.svg
@@ -34,5 +34,15 @@
     <symbol id="icon-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
     </symbol>
+
+    <!-- ICON_SEARCH -->
+    <symbol id="icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+    </symbol>
+
+    <!-- ICON_CLOSE -->
+    <symbol id="icon-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+    </symbol>
   </defs>
 </svg>

--- a/utils/mock_data.py
+++ b/utils/mock_data.py
@@ -1,0 +1,64 @@
+"""Mock data for development and testing."""
+
+# =============================================================================
+# MOCK DATA - ESTRUCTURA PARA PRODUCCIÓN
+# =============================================================================
+# En producción, cada conversación viene de SQLite (conversations.db)
+# con la siguiente estructura:
+#
+# {
+#     "id": str,              # UUID único de la conversación
+#     "title": str,           # Título de la conversación (max ~50 chars para UI)
+#     "created_at": str,      # ISO 8601 timestamp: "2026-01-06T14:30:00"
+#     "updated_at": str,      # ISO 8601 timestamp de última actualización
+# }
+#
+# El agrupamiento por fecha (HOY, AYER, ÚLTIMOS 7 DÍAS, etc.) se calcula
+# en conversation_service.py comparando 'created_at' con datetime.now()
+# =============================================================================
+
+MOCK_CONVERSATIONS = {
+    "HOY": [
+        {
+            "id": "conv-001",
+            "title": "Ley de Protección de Datos",
+            "created_at": "2026-01-06T10:30:00",
+        }
+    ],
+    "AYER": [
+        {
+            "id": "conv-002", 
+            "title": "Normas de Comercio Exterior",
+            "created_at": "2026-01-05T15:45:00",
+        }
+    ],
+    "ÚLTIMOS 7 DÍAS": [
+        {
+            "id": "conv-003",
+            "title": "Reforma Fiscal 2026",
+            "created_at": "2026-01-02T09:00:00",
+        },
+        {
+            "id": "conv-004",
+            "title": "Reglamento de Construcción",
+            "created_at": "2026-01-01T11:20:00",
+        },
+        {
+            "id": "conv-005",
+            "title": "Ley General de Salud",
+            "created_at": "2025-12-31T16:00:00",
+        }
+    ],
+    "ÚLTIMOS 30 DÍAS": [
+        {
+            "id": "conv-006",
+            "title": "Código de Comercio",
+            "created_at": "2025-12-20T14:00:00",
+        },
+        {
+            "id": "conv-007",
+            "title": "Ley Federal del Trabajo",
+            "created_at": "2025-12-15T10:30:00",
+        }
+    ]
+}

--- a/utils/mock_history_data.py
+++ b/utils/mock_history_data.py
@@ -1,22 +1,5 @@
 """Mock data for development and testing."""
 
-# =============================================================================
-# MOCK DATA - ESTRUCTURA PARA PRODUCCIÓN
-# =============================================================================
-# En producción, cada conversación viene de SQLite (conversations.db)
-# con la siguiente estructura:
-#
-# {
-#     "id": str,              # UUID único de la conversación
-#     "title": str,           # Título de la conversación (max ~50 chars para UI)
-#     "created_at": str,      # ISO 8601 timestamp: "2026-01-06T14:30:00"
-#     "updated_at": str,      # ISO 8601 timestamp de última actualización
-# }
-#
-# El agrupamiento por fecha (HOY, AYER, ÚLTIMOS 7 DÍAS, etc.) se calcula
-# en conversation_service.py comparando 'created_at' con datetime.now()
-# =============================================================================
-
 MOCK_CONVERSATIONS = {
     "HOY": [
         {


### PR DESCRIPTION
## Description

* **Goal:** Implement a conversation history sidebar panel design, including expanded/collapsed states, inline search view, and contextual menus.

* **Summary of changes:**
  - **`components/conversation_card.py`**: New `ConversationCard` component with static methods for:
    - `create()` – Individual conversation cards with action dropdown (share, rename, delete)
    - `create_group()` – Conversation grouping by date (Today, Yesterday, etc.)
    - `create_panel()` – Collapsible sidebar with toggle, "New conversation" button, history list, and settings footer
    - `create_search_view()` – Inline search view that replaces the chat area
    - `create_mobile_toggle()` / `create_overlay()` – Mobile support with overlay
  - **`pages/conversation_new.py`**: Sidebar integration with main layout using `ConversationCard.create_panel()` and `create_search_view()`
  - **`static/js/history.js`**: `HistoryPanel` class with logic for:
    - Sidebar toggle (expand/collapse)
    - Dropdown handling with data attributes
  - **`static/css/history.css`**: Minimal styles complementing Tailwind (layout, scrollbars, animations)

* **Key features:**
  - Collapsible sidebar (380px → 52px) using Tailwind `data-[state]` attributes
  - Contextual menu per conversation (3 dots)
  - Inline search with instant filtering

## How to test or use

1. Navigate to `/conversation/new` or the chat route
2. Verify sidebar displays conversations grouped by date
3. Click hamburger icon to collapse/expand sidebar
4. In collapsed state: should only show icons (hamburger, +, settings)
5. Click the 3 dots on a conversation → dropdown with actions
6. Type in search field → filters results in real-time
7. Click on result → returns to chat with that conversation selected

![side-bar](https://github.com/user-attachments/assets/204afc52-6c1d-4a97-a79a-1863766462ee)

